### PR TITLE
chore: Upgrade cache action to v4, bump CACHE_SEED

### DIFF
--- a/.github/actions/acmg-class-by-freq/action.yml
+++ b/.github/actions/acmg-class-by-freq/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Check cache ACMG class by freq. output
       id: check-cache-acmg-class-by-freq-output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/acmg-class-by-freq
         key: acmg-class-by-freq-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -47,7 +47,7 @@ runs:
       if: |
         (steps.check-cache-acmg-class-by-freq-output.outputs.cache-hit != 'true') ||
         (inputs.publish-artifacts == 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/acmg-class-by-freq
         key: acmg-class-by-freq-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -55,7 +55,7 @@ runs:
     - name: Retrieve cached ClinVar JSONL file
       if: |
         (steps.check-cache-acmg-class-by-freq-output.outputs.cache-hit != 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output

--- a/.github/actions/convert-clinvar/action.yml
+++ b/.github/actions/convert-clinvar/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Check cache JSONL output
       id: check-cache-convert-clinvar-output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -47,7 +47,7 @@ runs:
       if: |
         (steps.check-cache-convert-clinvar-output.outputs.cache-hit != 'true') ||
         (inputs.publish-artifacts == 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -55,7 +55,7 @@ runs:
     - name: Retrieve cached ClinVar file
       if: |
         (steps.check-cache-convert-clinvar-output.outputs.cache-hit != 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.CLINVAR_DIR }}
         key: download-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}

--- a/.github/actions/download-clinvar/action.yml
+++ b/.github/actions/download-clinvar/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Check for cache downloaded ClinVar file
       id: check-cache-clinvar-file
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.CLINVAR_DIR }}
         key: download-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}
@@ -20,7 +20,7 @@ runs:
 
     - name: Cache downloaded ClinVar file
       if: steps.check-cache-clinvar-file.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.CLINVAR_DIR }}
         key: download-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}

--- a/.github/actions/extract-vars/action.yml
+++ b/.github/actions/extract-vars/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Check cache variant extraction output
       id: check-cache-extract-vars-output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/extract-vars
         key: extract-vars-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -47,7 +47,7 @@ runs:
       if: |
         (steps.check-cache-extract-vars-output.outputs.cache-hit != 'true') ||
         (inputs.publish-artifacts == 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/extract-vars
         key: extract-vars-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -55,7 +55,7 @@ runs:
     - name: Retrieve cached ClinVar JSONL file
       if: |
         (steps.check-cache-extract-vars-output.outputs.cache-hit != 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output

--- a/.github/actions/gene-variant-report/action.yml
+++ b/.github/actions/gene-variant-report/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Check cache gene variant report output
       id: check-cache-gene-variant-report-output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/gene-variant-report
         key: gene-variant-report-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -47,7 +47,7 @@ runs:
       if: |
         (steps.check-cache-gene-variant-report-output.outputs.cache-hit != 'true') ||
         (inputs.publish-artifacts == 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/gene-variant-report
         key: gene-variant-report-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -55,7 +55,7 @@ runs:
     - name: Retrieve cached ClinVar JSONL file
       if: |
         (steps.check-cache-gene-variant-report-output.outputs.cache-hit != 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output

--- a/.github/actions/phenotype-links/action.yml
+++ b/.github/actions/phenotype-links/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Check cache phenotype links output
       id: check-cache-phenotype-links-output
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/phenotype-links
         key: phenotype-links-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -47,7 +47,7 @@ runs:
       if: |
         (steps.check-cache-phenotype-links-output.outputs.cache-hit != 'true') ||
         (inputs.publish-artifacts == 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/phenotype-links
         key: phenotype-links-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output
@@ -55,7 +55,7 @@ runs:
     - name: Retrieve cached ClinVar JSONL file
       if: |
         (steps.check-cache-phenotype-links-output.outputs.cache-hit != 'true')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.OUTPUT_DIR }}/convert-clinvar
         key: convert-clinvar-${{ env.CACHE_SEED }}-${{ steps.get-clinvar.outputs.release-name }}-${{ env.CLINVAR_THIS_VERSION }}-${{ env.MAX_RECORDS }}-output

--- a/.github/workflows/-build-artifacts.yml
+++ b/.github/workflows/-build-artifacts.yml
@@ -28,7 +28,7 @@ env:
   # clinvar-this package version
   CLINVAR_THIS_VERSION: "0.18.0"
   # Helper to get unique cache keys
-  CACHE_SEED: "0"
+  CACHE_SEED: "1"
   # Maximal number of records to process (0 = no limit).
   MAX_RECORDS: "0"
   # Lower verbosity of TQDM progress bar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions cache version from v3 to v4 across multiple workflow files
	- Modified cache seed value in build artifacts workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->